### PR TITLE
bugfix: prevent display of stappler issue when renaming a project with a space in new name

### DIFF
--- a/src/main/java/hudson/plugins/createjobadvanced/AbstractConfigurer.java
+++ b/src/main/java/hudson/plugins/createjobadvanced/AbstractConfigurer.java
@@ -1,5 +1,7 @@
 package hudson.plugins.createjobadvanced;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.model.AbstractItem;
 import hudson.model.Hudson;
 import hudson.model.Item;
@@ -17,22 +19,37 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import jenkins.model.Jenkins;
-import org.jenkinsci.plugins.matrixauth.AuthorizationType;
 import org.jenkinsci.plugins.matrixauth.PermissionEntry;
 import org.jenkinsci.plugins.matrixauth.inheritance.InheritParentStrategy;
 import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategy;
 
+/**
+ * Partial default implementation of item configurers.
+ * <P>
+ * Used to apply plugin configuration to items
+ *
+ * @author Laurent Coltat
+ */
 public abstract class AbstractConfigurer<T extends AbstractItem, A> {
+
+    /**
+     * Plugin logger
+     */
     protected static final Logger log = Logger.getLogger(CreateJobAdvancedPlugin.class.getName());
 
-    protected void onCreated(Item item) {
+    /**
+     * Update given Item according to plugin configuration.
+     *
+     * @param item item to be updated
+     */
+    protected void doCreate(Item item) {
         final CreateJobAdvancedPlugin cja = getPlugin();
         if (null == cja) {
             return;
         }
         log.finest("> AbstractConfigurer.onCreated()");
 
-        onRenamed(item);
+        doRename(item);
 
         // hudson must activate security mode for using
         Jenkins jenkinsInstance = Hudson.getInstanceOrNull();
@@ -46,16 +63,14 @@ public abstract class AbstractConfigurer<T extends AbstractItem, A> {
 
         if (cja.isAutoOwnerRights()) {
             String sid = Hudson.getAuthentication2().getName();
-            securityGrantPermissions(
-                    item,
-                    sid,
-                    new Permission[] {Item.CONFIGURE, Item.BUILD, Item.READ, Item.DELETE, Item.WORKSPACE},
-                    AuthorizationType.USER);
+            securityGrantPermissions(item, PermissionEntry.user(sid), new Permission[] {
+                Item.CONFIGURE, Item.BUILD, Item.READ, Item.DELETE, Item.WORKSPACE
+            });
         }
 
         if (cja.isAutoPublicBrowse()) {
             securityGrantPermissions(
-                    item, "anonymous", new Permission[] {Item.READ, Item.WORKSPACE}, AuthorizationType.USER);
+                    item, PermissionEntry.user("anonymous"), new Permission[] {Item.READ, Item.WORKSPACE});
         }
 
         if (cja.isActiveDynamicPermissions()) {
@@ -64,24 +79,30 @@ public abstract class AbstractConfigurer<T extends AbstractItem, A> {
         log.finest("< AbstractConfigurer.onCreated()");
     }
 
-    protected final void onRenamed(Item item) {
+    /**
+     * Rename given item if plugin configuration request it.
+     *
+     * @param item to be renamed
+     */
+    protected final String doRename(Item item) {
+        String resulString = item.getName();
         final CreateJobAdvancedPlugin cja = getPlugin();
-        if (null == cja) {
-            return;
-        }
-        log.finest("> AbstractConfigurer.onRenamed()");
-        if (cja.isReplaceSpace()) {
+        if (null != cja && cja.isReplaceSpace()) {
             if (item.getName().indexOf(" ") != -1) {
                 try {
-                    renameJob(item, item.getName().replaceAll(" ", "-"));
-                } catch (IOException e) {
+                    resulString = item.getName().replaceAll(" ", "-");
+                    renameJob(item, resulString);
+                } catch (Exception e) {
                     log.log(Level.SEVERE, "error during rename", e);
                 }
             }
         }
-        log.finest("< AbstractConfigurer.onRenamed()");
+        return resulString;
     }
 
+    /**
+     * @return plugin configuration instance.identity/
+     */
     protected final CreateJobAdvancedPlugin getPlugin() {
         Jenkins instance = Jenkins.getInstanceOrNull();
         if (null == instance) {
@@ -95,14 +116,20 @@ public abstract class AbstractConfigurer<T extends AbstractItem, A> {
         return result;
     }
 
-    private final void securityGrantDynamicPermissions(final Item abstractItem, CreateJobAdvancedPlugin cja) {
+    /**
+     * Grant dynamic group permissions to given item according to plugin configuration.
+     *
+     * @param item item to be granted
+     * @param cja plugin configuration
+     */
+    private final void securityGrantDynamicPermissions(final Item item, CreateJobAdvancedPlugin cja) {
         String patternStr = cja.getExtractPattern(); // com.([A-Z]{3}).(.*)
 
         List<String> groupsList = new ArrayList<String>();
 
         if (patternStr != null) {
             Pattern pattern = Pattern.compile(patternStr);
-            Matcher matcher = pattern.matcher(abstractItem.getName());
+            Matcher matcher = pattern.matcher(item.getName());
             boolean matchFound = matcher.find();
 
             if (matchFound) {
@@ -127,40 +154,40 @@ public abstract class AbstractConfigurer<T extends AbstractItem, A> {
                 permissionList.add(permForId);
             }
 
-            securityGrantPermissions(
-                    abstractItem,
-                    newName,
-                    (Permission[]) permissionList.toArray(new Permission[permissionList.size()]),
-                    AuthorizationType.GROUP);
+            securityGrantPermissions(item, PermissionEntry.group(newName), (Permission[])
+                    permissionList.toArray(new Permission[permissionList.size()]));
         }
     }
 
+    /**
+     * Grant given Jenkins permissions to given item for given sid of given type.
+     *
+     * @param item item to be granted
+     * @param permEnt Permission entry
+     * @param jenkinsPermissions permissions to grant
+     */
     protected final void securityGrantPermissions(
-            final Item item, String sid, Permission[] hudsonPermissions, AuthorizationType type) {
-        PermissionEntry permEnt = new PermissionEntry(AuthorizationType.EITHER, sid);
-        switch (type) {
-            case USER:
-                permEnt = PermissionEntry.user(sid);
-                break;
-            case GROUP:
-                permEnt = PermissionEntry.group(sid);
-                break;
-            case EITHER:
-                break;
-        }
+            final Item item, PermissionEntry permEnt, Permission[] jenkinsPermissions) {
 
         Map<Permission, Set<PermissionEntry>> permissions = initPermissions(item);
-        for (Permission perm : hudsonPermissions) {
+        for (Permission perm : jenkinsPermissions) {
             configurePermission(permissions, perm, permEnt);
         }
         try {
-            addAuthorizationMatrixProperty(item, permissions);
+            A authProperty = setupAuthorizationMatrixProperty(permissions);
+            addAuthorizationMatrixProperty(item, authProperty);
         } catch (IOException e) {
             log.log(Level.SEVERE, "problem to add granted permissions", e);
         }
     }
 
-    protected final Map<Permission, Set<PermissionEntry>> initPermissions(Item item) {
+    /**
+     * Retrive existing Jenkins permissions map granted to given item.
+     *
+     * @param item item to be parsed
+     * @return Jenkins permissions map granted to given item
+     */
+    protected final @NonNull Map<Permission, Set<PermissionEntry>> initPermissions(@Nullable Item item) {
         // if you create the job with template, need to get informations
         A auth = getAuthorizationMatrixProperty(item);
         Map<Permission, Set<PermissionEntry>> permissions = getGrantedPermissionEntries(auth);
@@ -169,26 +196,36 @@ public abstract class AbstractConfigurer<T extends AbstractItem, A> {
         return permissions;
     }
 
+    /**
+     * Associates given permission entry to given Jenkins permission, and add it to given permissions map.
+     *
+     * @param permissions map of Jenkins permissions linked to their assigned permission entries
+     * @param permission permission to be configured
+     * @param permissionEntry permission entry
+     */
     protected final void configurePermission(
-            Map<Permission, Set<PermissionEntry>> permissions, Permission permission, PermissionEntry sid) {
+            Map<Permission, Set<PermissionEntry>> permissions, Permission permission, PermissionEntry permissionEntry) {
 
-        Set<PermissionEntry> sidPermission = permissions.get(permission);
-        if (sidPermission == null) {
+        Set<PermissionEntry> sidPermissionSet = permissions.get(permission);
+        if (sidPermissionSet == null) {
             Set<PermissionEntry> sidSet = new HashSet<PermissionEntry>();
-
-            sidSet.add(sid);
+            sidSet.add(permissionEntry);
             permissions.put(permission, sidSet);
         } else {
-            if (!sidPermission.contains(sid)) {
-                sidPermission.add(sid);
+            if (!sidPermissionSet.contains(permissionEntry)) {
+                sidPermissionSet.add(permissionEntry);
             }
         }
     }
 
-    protected final void addAuthorizationMatrixProperty(Item item, Map<Permission, Set<PermissionEntry>> permissions)
+    /**
+     * Creates authorization matrix property from given permission map.
+     *
+     * @param permissions map of permissions linked to their assigned permissions entries
+     * @throws IOException
+     */
+    protected final A setupAuthorizationMatrixProperty(Map<Permission, Set<PermissionEntry>> permissions)
             throws IOException {
-        log.finer("> " + this.getClass().getName()
-                + ".addAuthorizationMatrixProperty(Item, Map<Permission, Set<PermissionEntry>>)");
 
         A authProperty = createAuthorizationMatrixProperty();
         setInheritanceStrategy(authProperty, new InheritParentStrategy());
@@ -209,28 +246,85 @@ public abstract class AbstractConfigurer<T extends AbstractItem, A> {
                 }
             }
         }
-        addAuthorizationMatrixProperty(item, authProperty);
-        log.finer("< " + this.getClass().getName()
-                + ".addAuthorizationMatrixProperty(Item, Map<Permission, Set<PermissionEntry>>)");
+
+        return authProperty;
     }
 
-    protected abstract void setInheritanceStrategy(A authProperty, InheritanceStrategy inheritanceStrategy);
+    /**
+     * Assign given inheritance strategy to given authorization matrix property.
+     *
+     * @param authProperty authorization matrix property to be updated
+     * @param inheritanceStrategy inheritance strategy to be assigned
+     */
+    protected abstract void setInheritanceStrategy(
+            @Nullable A authProperty, @Nullable InheritanceStrategy inheritanceStrategy);
 
-    protected abstract void addPermission(A authProperty, Permission perm, PermissionEntry permEntry);
+    /**
+     * Associate given Jenkins permission to given permission entry and assign it to given authorization property.
+     *
+     * @param authProperty authorization matrix property to be updated
+     * @param perm Jenkins permission to be assigned
+     * @param permEntry permission entry to be associated
+     */
+    protected abstract void addPermission(
+            @Nullable A authProperty, @Nullable Permission perm, @Nullable PermissionEntry permEntry);
 
-    protected abstract boolean showPermission(Permission perm);
+    /**
+     * Check if given Jenkins permission is handled by this object.
+     *
+     * @param perm Jenkins permission
+     * @return true if parameter is available
+     */
+    protected abstract boolean showPermission(@Nullable Permission perm);
 
-    protected abstract void addAuthorizationMatrixProperty(Item item, A authProperty) throws IOException;
+    /**
+     * Assigne given authorization matrix property to given item.
+     *
+     * @param item Item to be updated
+     * @param authProperty authorization matrix property to be assigned
+     * @throws IOException
+     */
+    protected abstract void addAuthorizationMatrixProperty(@Nullable Item item, @Nullable A authProperty)
+            throws IOException;
 
-    protected abstract void renameJob(Item item, String newName) throws IOException;
+    /**
+     * Rename given item with given name.
+     *
+     * @param item Item to be updated
+     * @param newName New name to be assigned
+     * @throws IOException
+     */
+    protected abstract void renameJob(@Nullable Item item, @Nullable String newName) throws IOException;
 
-    /*protected abstract void addAuthorizationMatrixProperty(Item item, Map<Permission, Set<PermissionEntry>> permissions)
-    throws IOException;*/
-    protected abstract A createAuthorizationMatrixProperty();
+    /**
+     * Create a fresh new authorization matrix property.
+     *
+     * @return created authorization matrix property
+     */
+    protected abstract @Nullable A createAuthorizationMatrixProperty();
 
-    protected abstract A getAuthorizationMatrixProperty(Item item);
+    /**
+     * Fetch autorization matrix property from given item.
+     *
+     * @param item owner of the autorization matrix property to be fetched
+     * @return autorization matrix property of given item if any, null otherwize
+     */
+    protected abstract @Nullable A getAuthorizationMatrixProperty(@Nullable Item item);
 
-    protected abstract boolean removeProperty(Item item, A authProperty);
+    /**
+     * Remove given authorization matrix from given item.
+     *
+     * @param item item to be updated
+     * @param authProperty authorization matrix to be removed
+     */
+    protected abstract void removeProperty(@Nullable Item item, @Nullable A authProperty);
 
-    protected abstract Map<Permission, Set<PermissionEntry>> getGrantedPermissionEntries(A authProperty);
+    /**
+     * Fetch association of Jenkins permissions to permission entries from given authorization matrix.auth.
+     *
+     * @param authProperty authorization matrix to be updated.
+     * @return a Map of Jenkins permissions linked to their assigned permissions entries.
+     */
+    protected abstract @NonNull Map<Permission, Set<PermissionEntry>> getGrantedPermissionEntries(
+            @Nullable A authProperty);
 }

--- a/src/main/java/hudson/plugins/createjobadvanced/CreateJobAdvancedPlugin.java
+++ b/src/main/java/hudson/plugins/createjobadvanced/CreateJobAdvancedPlugin.java
@@ -115,6 +115,8 @@ public class CreateJobAdvancedPlugin extends Plugin {
      * adds a dynamic permission configuration with the data extracted form the
      * jsonObject.
      *
+     * @param req
+     * @param jsonObject
      */
     private void addDynamicPermission(StaplerRequest2 req, JSONObject jsonObject) {
         final DynamicPermissionConfig dynPerm = req.bindJSON(DynamicPermissionConfig.class, jsonObject);
@@ -134,6 +136,10 @@ public class CreateJobAdvancedPlugin extends Plugin {
         dynamicPermissionConfigs.add(dynPerm);
     }
 
+    /**
+     *
+     * @return
+     */
     public static Map<String, List<Permission>> getAllPossiblePermissions() {
         final Map<String, List<Permission>> enabledPerms = new TreeMap<String, List<Permission>>();
 
@@ -143,6 +149,11 @@ public class CreateJobAdvancedPlugin extends Plugin {
         return enabledPerms;
     }
 
+    /**
+     *
+     * @param p
+     * @return
+     */
     public static String impliedByList(Permission p) {
         List<Permission> impliedBys = new ArrayList<>();
         while (p.impliedBy != null) {
@@ -152,6 +163,11 @@ public class CreateJobAdvancedPlugin extends Plugin {
         return StringUtils.join(impliedBys.stream().map(Permission::getId).collect(Collectors.toList()), " ");
     }
 
+    /**
+     *
+     * @param allEnabledPerms
+     * @param owner
+     */
     private static void addEnabledPermissionsForGroup(
             final Map<String, List<Permission>> allEnabledPerms, Class<?> owner) {
         final PermissionGroup permissionGroup = PermissionGroup.get(owner);
@@ -169,34 +185,66 @@ public class CreateJobAdvancedPlugin extends Plugin {
         }
     }
 
+    /**
+     *
+     * @return true when automatic owner right assigment  option is activated
+     */
     public boolean isAutoOwnerRights() {
         return autoOwnerRights;
     }
 
+    /**
+     *
+     * @return true when automatic public browse assigment option is activated
+     */
     public boolean isAutoPublicBrowse() {
         return autoPublicBrowse;
     }
 
+    /**
+     *
+     * @return true when replace space option is activated
+     */
     public boolean isReplaceSpace() {
         return replaceSpace;
     }
 
+    /**
+     *
+     * @return true when log rotator option is activated
+     */
     public boolean isActiveLogRotator() {
         return activeLogRotator;
     }
 
+    /**
+     *
+     * @return the days to keep builds
+     */
     public int getDaysToKeep() {
         return daysToKeep;
     }
 
+    /**
+     *
+     * @return the number of build to be kept
+     */
     public int getNumToKeep() {
         return numToKeep;
     }
 
+    /**
+     *
+     * @return the days to keep build artifacts
+     */
     public int getArtifactDaysToKeep() {
         return artifactDaysToKeep;
     }
 
+    /**
+     *
+     * @return the number of build to keep with artifacts
+     */
     public int getArtifactNumToKeep() {
         return artifactNumToKeep;
     }
@@ -215,10 +263,18 @@ public class CreateJobAdvancedPlugin extends Plugin {
         return activeDynamicPermissions;
     }
 
+    /**
+     *
+     * @return
+     */
     public boolean isMvnArchivingDisabled() {
         return mvnArchivingDisabled;
     }
 
+    /**
+     *
+     * @return
+     */
     public boolean isMvnPerModuleEmail() {
         return mvnPerModuleEmail;
     }

--- a/src/main/java/hudson/plugins/createjobadvanced/DynamicPermissionConfig.java
+++ b/src/main/java/hudson/plugins/createjobadvanced/DynamicPermissionConfig.java
@@ -18,6 +18,11 @@ public class DynamicPermissionConfig {
         }
     }
 
+    /**
+     * Add given permission ID to checked permission set.
+     *
+     * @param permissionId permission ID to be added to checked permission IDs set.
+     */
     public void addPermissionId(String permissionId) {
         checkedPermissionIds.add(permissionId);
     }
@@ -30,12 +35,18 @@ public class DynamicPermissionConfig {
     }
 
     /**
-     * @return the checkedPermissionIds
+     * @return the checked permission IDs set
      */
     public Set<String> getCheckedPermissionIds() {
         return checkedPermissionIds;
     }
 
+    /**
+     * Check given permission state.
+     *
+     * @param permission
+     * @return true if given permission is checked, false otherwise
+     */
     public boolean isPermissionChecked(Permission permission) {
         return checkedPermissionIds.contains(permission.getId());
     }

--- a/src/main/java/hudson/plugins/createjobadvanced/FolderConfigurer.java
+++ b/src/main/java/hudson/plugins/createjobadvanced/FolderConfigurer.java
@@ -2,6 +2,7 @@ package hudson.plugins.createjobadvanced;
 
 import com.cloudbees.hudson.plugins.folder.AbstractFolder;
 import com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.model.Item;
 import hudson.security.Permission;
 import java.io.IOException;
@@ -13,120 +14,133 @@ import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.matrixauth.PermissionEntry;
 import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategy;
 
-public class FolderConfigurer extends AbstractConfigurer<AbstractFolder<?>, AuthorizationMatrixProperty> {
+/**
+ * Changes the configuration of {@link AbstractFolder<?>} items.
+ *
+ * @author Laurent Coltat
+ */
+public final class FolderConfigurer extends AbstractConfigurer<AbstractFolder<?>, AuthorizationMatrixProperty> {
 
+    /**
+     * Class contructor
+     */
     protected FolderConfigurer() {}
 
     @Override
-    protected void onCreated(Item item) {
-        if ((item instanceof AbstractFolder<?>)) {
-            log.finer("> " + this.getClass().getName() + ".onCreated()");
-            super.onCreated(item);
-            log.finer("< " + this.getClass().getName() + ".onCreated()");
+    protected void doCreate(@Nullable Item item) {
+        if (null != item && item instanceof AbstractFolder<?>) {
+            super.doCreate(item);
         }
     }
 
     @Override
-    protected void renameJob(Item item, String newName) throws IOException {
-        if ((item instanceof AbstractFolder<?>)) {
-            log.finer("> " + this.getClass().getName() + ".renameJob()");
+    protected void renameJob(@Nullable Item item, @Nullable String newName) throws IOException {
+        if (null != item && null != newName && item instanceof AbstractFolder<?>) {
             AbstractFolder<?> folder = (AbstractFolder<?>) item;
             folder.renameTo(newName);
-            log.finer("< " + this.getClass().getName() + ".renameJob()");
         }
     }
 
     @Override
     protected Map<Permission, Set<PermissionEntry>> getGrantedPermissionEntries(
-            AuthorizationMatrixProperty authProperty) {
-        log.finer("> " + this.getClass().getName() + ".getGrantedPermissionEntries()");
+            @Nullable AuthorizationMatrixProperty authProperty) {
+        Map<Permission, Set<PermissionEntry>> result = null;
+
         if (null == authProperty) {
-            return new HashMap<Permission, Set<PermissionEntry>>();
+            result = new HashMap<Permission, Set<PermissionEntry>>();
+        } else {
+            result = new HashMap<Permission, Set<PermissionEntry>>(authProperty.getGrantedPermissionEntries());
         }
-        log.finer("< " + this.getClass().getName() + ".addAuthorizationMatrixProperty()");
-        return new HashMap<Permission, Set<PermissionEntry>>(authProperty.getGrantedPermissionEntries());
+
+        return result;
     }
 
     @Override
-    protected AuthorizationMatrixProperty getAuthorizationMatrixProperty(Item item) {
-        if (!(item instanceof AbstractFolder<?>)) {
-            return null;
+    @Nullable
+    protected AuthorizationMatrixProperty getAuthorizationMatrixProperty(@Nullable Item item) {
+        AuthorizationMatrixProperty result = null;
+        if (null != item && item instanceof AbstractFolder<?>) {
+            AbstractFolder<?> folder = (AbstractFolder<?>) item;
+            result = folder.getProperties().get(AuthorizationMatrixProperty.class);
         }
-        AbstractFolder<?> folder = (AbstractFolder<?>) item;
-        return folder.getProperties().get(AuthorizationMatrixProperty.class);
+        return result;
     }
 
     @Override
-    protected boolean removeProperty(Item item, AuthorizationMatrixProperty authProperty) {
-        if (!(item instanceof AbstractFolder<?>)) {
-            return false;
+    protected void removeProperty(@Nullable Item item, @Nullable AuthorizationMatrixProperty authProperty) {
+        if (null == item || !(item instanceof AbstractFolder<?>)) {
+            return;
         }
         if (null == authProperty) {
-            return false;
+            return;
         }
         AbstractFolder<?> folder = (AbstractFolder<?>) item;
         List<?> folderProperties = folder.getProperties();
-        return folderProperties.remove(authProperty);
+        folderProperties.remove(authProperty);
     }
 
+    @Nullable
     private final AuthorizationMatrixProperty.DescriptorImpl getAuthorizationPropertyDescriptor() {
         AuthorizationMatrixProperty.DescriptorImpl result = (AuthorizationMatrixProperty.DescriptorImpl)
                 (Jenkins.get().getDescriptor(AuthorizationMatrixProperty.class));
-        if (result == null) {
+        if (null == result) {
             log.warning(AuthorizationMatrixProperty.DescriptorImpl.class.getName() + " is null");
         }
         return result;
     }
 
     @Override
-    protected void addAuthorizationMatrixProperty(Item item, AuthorizationMatrixProperty authProperty)
+    protected void addAuthorizationMatrixProperty(@Nullable Item item, AuthorizationMatrixProperty authProperty)
             throws IOException {
-        log.finer("> " + this.getClass().getName()
-                + ".addAuthorizationMatrixProperty(Item, AuthorizationMatrixProperty)");
+        if (null == item || null == authProperty) {
+            return;
+        }
         if (!(item instanceof AbstractFolder<?>)) {
-            log.warning("JobConfigurer.onCreated() non applicable for "
+            log.finest("JobConfigurer.onCreated() non applicable for "
                     + item.getClass().getName());
-            log.finer("< " + this.getClass().getName()
-                    + ".addAuthorizationMatrixProperty(Item, AuthorizationMatrixProperty)");
             return;
         }
         AbstractFolder<?> folder = (AbstractFolder<?>) item;
         folder.addProperty(authProperty);
-        log.finer("< " + this.getClass().getName()
-                + ".addAuthorizationMatrixProperty(Item, AuthorizationMatrixProperty)");
     }
 
     @Override
+    @Nullable
     protected AuthorizationMatrixProperty createAuthorizationMatrixProperty() {
+        AuthorizationMatrixProperty result = null;
+
         AuthorizationMatrixProperty.DescriptorImpl propDescriptor = getAuthorizationPropertyDescriptor();
-        if (propDescriptor == null) {
-            log.finer("< " + this.getClass().getName()
-                    + ".addAuthorizationMatrixProperty(Item, Map<Permission, Set<PermissionEntry>>)");
-            return null;
+        if (null != propDescriptor) {
+            result = propDescriptor.create();
         }
 
-        return propDescriptor.create();
+        return result;
     }
 
     @Override
     protected void setInheritanceStrategy(
-            AuthorizationMatrixProperty authProperty, InheritanceStrategy inheritanceStrategy) {
-        authProperty.setInheritanceStrategy(inheritanceStrategy);
-    }
-
-    @Override
-    protected void addPermission(AuthorizationMatrixProperty authProperty, Permission perm, PermissionEntry permEntry) {
-        authProperty.add(perm, permEntry);
-    }
-
-    @Override
-    protected boolean showPermission(Permission perm) {
-        AuthorizationMatrixProperty.DescriptorImpl propDescriptor = getAuthorizationPropertyDescriptor();
-        if (propDescriptor == null) {
-            log.finer("< " + this.getClass().getName()
-                    + ".addAuthorizationMatrixProperty(Item, Map<Permission, Set<PermissionEntry>>)");
-            return false;
+            @Nullable AuthorizationMatrixProperty authProperty, InheritanceStrategy inheritanceStrategy) {
+        if (null != authProperty) {
+            authProperty.setInheritanceStrategy(inheritanceStrategy);
         }
-        return propDescriptor.showPermission(perm);
+    }
+
+    @Override
+    protected void addPermission(
+            @Nullable AuthorizationMatrixProperty authProperty, Permission perm, PermissionEntry permEntry) {
+        if (null != authProperty) {
+            authProperty.add(perm, permEntry);
+        }
+    }
+
+    @SuppressWarnings("null")
+    @Override
+    protected boolean showPermission(@Nullable Permission perm) {
+        AuthorizationMatrixProperty.DescriptorImpl propDescriptor = getAuthorizationPropertyDescriptor();
+        boolean result = false;
+        if (null == propDescriptor || null == perm) {
+            result = propDescriptor.showPermission(perm);
+        }
+        return result;
     }
 }

--- a/src/main/java/hudson/plugins/createjobadvanced/ItemListenerImpl.java
+++ b/src/main/java/hudson/plugins/createjobadvanced/ItemListenerImpl.java
@@ -5,69 +5,84 @@ import hudson.model.Item;
 import hudson.model.listeners.ItemListener;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerResponse2;
 
+/**
+ * Item listener in charge to apply plugin configuration on created or renamed items.
+ */
 @Extension
 public class ItemListenerImpl extends ItemListener {
-
+    /**
+     * Plugin logger
+     */
     private static final Logger log = Logger.getLogger(CreateJobAdvancedPlugin.class.getName());
 
+    /**
+     * Available Item configurers list
+     */
     private List<AbstractConfigurer<?, ?>> configurers = new ArrayList<AbstractConfigurer<?, ?>>();
 
+    /**
+     * Class constructor in charge to initialize item configurers according to available plugins.
+     */
     @DataBoundConstructor
     public ItemListenerImpl() {
-        log.finer("> ItemListenerImpl()");
         Jenkins instance = Jenkins.getInstanceOrNull();
         if (null != instance) {
             if (null != instance.getPlugin("maven-plugin")) {
-                log.finer("> ItemListenerImpl() registering MavenConfigurer");
                 MavenConfigurer mavenConfigurer = new MavenConfigurer();
                 log.finer(mavenConfigurer.toString());
                 configurers.add(mavenConfigurer);
-                log.finer("< ItemListenerImpl() registered MavenConfigurer");
             } else {
-                log.finer("> ItemListenerImpl() registering JobConfigurer");
                 JobConfigurer jobConfigurer = new JobConfigurer();
                 log.finer(jobConfigurer.toString());
                 configurers.add(jobConfigurer);
-                log.finer("< ItemListenerImpl() registered JobConfigurer");
             }
             if (null != instance.getPlugin("cloudbees-folder")) {
-                log.finer("> ItemListenerImpl() registering FolderConfigurer");
                 FolderConfigurer folderConfigurer = new FolderConfigurer();
                 log.finer(folderConfigurer.toString());
                 configurers.add(folderConfigurer);
-                log.finer("< ItemListenerImpl() registered FolderConfigurer");
             }
         }
-        log.finer("< ItemListenerImpl()");
     }
 
     @Override
     public void onRenamed(Item item, String oldName, String newName) {
-        log.finer("> ItemListenerImpl.onRenamed()");
-
+        final Object[] params = {oldName, newName};
+        log.entering(getClass().getSimpleName(), "onRenamed", params);
         for (AbstractConfigurer<?, ?> configurer : configurers) {
-            log.finer("> " + configurer.getClass().getName() + ".onRenamed()");
-            configurer.onRenamed(item);
-            log.finer("< " + configurer.getClass().getName() + ".onRenamed()");
+            boolean isRespCommitted = false;
+            try {
+                String name = configurer.doRename(item);
+                if (newName.compareTo(name) != 0) {
+                    StaplerResponse2 rsp = Stapler.getCurrentResponse2();
+                    if (null != rsp) {
+                        isRespCommitted = rsp.isCommitted();
+                        rsp.sendRedirect2("../" + name);
+                    }
+                }
+            } catch (java.lang.IllegalStateException e) {
+                log.finest("resp.isCommitted()=" + isRespCommitted);
+                if (false == isRespCommitted) {
+                    log.log(Level.SEVERE, "error during sendRedirect2", e);
+                }
+            } catch (java.io.IOException e) {
+                log.log(Level.SEVERE, "error during sendRedirect2", e);
+                e.printStackTrace();
+            }
         }
-
-        log.finer("< ItemListenerImpl.onRenamed()");
+        log.exiting(getClass().getSimpleName(), "onRenamed");
     }
 
     @Override
     public void onCreated(Item item) {
-        log.finer("> ItemListenerImpl.onCreated()");
-
         for (AbstractConfigurer<?, ?> configurer : configurers) {
-            log.finer("> " + configurer.getClass().getName() + ".onCreated()");
-            configurer.onCreated(item);
-            log.finer("< " + configurer.getClass().getName() + ".onCreated()");
+            configurer.doCreate(item);
         }
-
-        log.finer("< ItemListenerImpl.onCreated()");
     }
 }

--- a/src/main/java/hudson/plugins/createjobadvanced/MavenConfigurer.java
+++ b/src/main/java/hudson/plugins/createjobadvanced/MavenConfigurer.java
@@ -23,23 +23,28 @@
  */
 package hudson.plugins.createjobadvanced;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.maven.MavenModuleSet;
 import hudson.maven.reporters.MavenMailer;
 import hudson.model.Item;
 
 /**
- * Changes the configuration of {@link MavenModuleSet}s.
+ * Changes the configuration of {@link MavenModuleSet} items.
  *
  * @author Dominik Bartholdi (imod)
+ * @author Laurent Coltat
  */
-public class MavenConfigurer extends JobConfigurer {
+public final class MavenConfigurer extends JobConfigurer {
 
+    /**
+     * Class constructor
+     */
     protected MavenConfigurer() {}
 
     @Override
-    public void onCreated(Item item) {
+    public final void doCreate(Item item) {
         log.finer("> " + this.getClass().getName() + ".onCreated()");
-        super.onCreated(item);
+        super.doCreate(item);
         if ((item instanceof MavenModuleSet)) {
             MavenModuleSet mavenModuleSet = (MavenModuleSet) item;
             preConfigureMavenJob(mavenModuleSet);
@@ -47,7 +52,11 @@ public class MavenConfigurer extends JobConfigurer {
         log.finer("< " + this.getClass().getName() + ".onCreated()");
     }
 
-    private void preConfigureMavenJob(MavenModuleSet mavenModuleSet) {
+    /**
+     *
+     * @param mavenModuleSet
+     */
+    private final void preConfigureMavenJob(@Nullable MavenModuleSet mavenModuleSet) {
         final CreateJobAdvancedPlugin cja = getPlugin();
         if (null == cja) {
             return;


### PR DESCRIPTION
If [Create Job Advanced](https://plugins.jenkins.io/createjobadvanced/) is configured to replace space in job name by `-` (dash), a stappler exception is displayed when trying to rename a project with a space in new job name, while everything goes fine when creating a project containing a space in its name.
More over same process applied to a folder, does not work at all, the plugin feature is not applied.

The purpose of this PR is to fix such issue, which is raised because onRename


### Testing done

1. Configure plugin to replace space in job name by `-` (dash)
2. Create a new project with a space in job name, as for instance `a test project` :arrow_right: job configuration page is displayed as `a-test-project` :heavy_check_mark: 
3. Save job configuration
4. Rename job in order to introduce a new space, as for instance `a wonderfull test-project` :arrow_right:, and confirm renaming :arrow_right: job is displayed as `a-wonderfull-test-project` :heavy_check_mark: 
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests that demonstrate the feature works or the issue is fixed