### PR TITLE
bugfix: Fix devcontainer startup & maven local repository location

### DIFF
--- a/.devcontainer/.env
+++ b/.devcontainer/.env
@@ -1,6 +1,7 @@
 USER_CI=jenkinsci
-LOCAL_UID=1000
-LOCAL_GID=1000
+# Local UID/GID are automatically filled at dev container startup
+LOCAL_UID=
+LOCAL_GID=
 
 # Image build settings - customize it in case of air-gapped environment
 # BASE_IMAGE=harbor.example.com/library/ubuntu:noble-20250127

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -56,4 +56,4 @@ EOF
 EOT
 # Add maven settings for jenkins ci
 RUN mkdir -p /home/${USER_CI}/.m2
-COPY resources/settings.xml /${USER_CI}/.m2
+COPY resources/settings.xml /home/${USER_CI}/.m2

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,10 +11,10 @@
 	},
 	"initializeCommand": {
 		"uid": [
-			"bash", "-c", "sed -i -E \"s|^(LOCAL_UID=).*|\\1$(id -u)|g\" ${localWorkspaceFolder}/.devcontainer/.env"
+			"bash", "-c", "sed -i -E \"s|^(LOCAL_UID=).*|\\1$(id -u)|g\" \"${localWorkspaceFolder}\"/.devcontainer/.env"
 		],
 		"gid": [
-			"bash", "-c", "sed -i -E \"s|^(LOCAL_GID=).*|\\1$(id -g)|g\" ${localWorkspaceFolder}/.devcontainer/.env"
+			"bash", "-c", "sed -i -E \"s|^(LOCAL_GID=).*|\\1$(id -g)|g\" \"${localWorkspaceFolder}\"/.devcontainer/.env"
 		]
 	}
 	// Features to add to the dev container. More info: https://containers.dev/features.

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ work
 *.iml
 .vscode/settings.json
 .m2repository
-.vscode-server
-
+.devcontainer/.env


### PR DESCRIPTION
1. When path to git local repository contains spaces, Dev Container failed to start

2. maven local repository is not embedded into workspace as it would

<!-- Please describe your pull request here. -->

### Testing done

* From VSCode, checkout plugin git repository into a location whom path contains spaces
* Open Dev Container :heavy_check_mark: remote container is well started
* Build the plugin :heavy_check_mark: maven local repository is located at workspace root level, as .m2 directory

### Submitter checklist
- [x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
