### PR TITLE
Migrate from Commons Lang to native Java Platform functionality

### DIFF
--- a/src/main/java/hudson/plugins/createjobadvanced/CreateJobAdvancedPlugin.java
+++ b/src/main/java/hudson/plugins/createjobadvanced/CreateJobAdvancedPlugin.java
@@ -16,7 +16,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.StaplerRequest2;
 
 /**
@@ -161,7 +160,7 @@ public class CreateJobAdvancedPlugin extends Plugin {
             p = p.impliedBy;
             impliedBys.add(p);
         }
-        return StringUtils.join(impliedBys.stream().map(Permission::getId).collect(Collectors.toList()), " ");
+        return impliedBys.stream().map(Permission::getId).collect(Collectors.joining(" "));
     }
 
     /**


### PR DESCRIPTION
No need to depend on a third-party library here when the Java Platform provides this functionality natively.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

`StringUtils.join(stream.collect(toList()), " ")` collapses into `Collectors.joining(" ")` on the
stream that was already there, which drops the intermediate list as well as the dependency. The stream
maps `Permission::getId`, so no element can be null and `joining` is a faithful swap.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.
The `ban-commons-lang-2` enforcer rule was left disabled because it needs parent POM
`6.2116.v7501b_67dc517` or newer; bumping the parent from `5.26` was out of scope here.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact
@parameter.
